### PR TITLE
Genericize simple deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Ultra-simple Magfest Prime deploy
+# Ultra-simple Generic RAMS deploy
 
 ## Prerequisites
 Install all this stuff:
 * [Git](http://git-scm.com/) to check out this repo and to provide SSH.
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads) for running your development VM.
 * [Vagrant](http://www.vagrantup.com/downloads.html) itself.
-
-You must have read access to http://github.com/magfest/production-config - if you get a 404 when you click that link, this won't work.
 
 ## before you begin
 
@@ -16,8 +14,10 @@ advanced: If you have previous deployments, you must ensure those VMs are stoppe
 
 1. clone this repo.
 2. double click deploy.bat
-3. about 3 minutes in, type in your github user/password
-4. after the deploy is finished, it will open a web browser, login with username 'magfest@example.com' and password 'magfest'
-5. type 'vagrant ssh' to access the running machine
+3. after the deploy is finished, it will open a web browser, login with username 'magfest@example.com' and password 'magfest'
+
+## How to SSH into the machine (optional)
+
+1. type 'vagrant ssh' to access the running machine
   
 

--- a/run-simple-deploy.sh
+++ b/run-simple-deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-EVENT_NAME=prime
+EVENT_NAME=test
 
 set -e
 
 cd ~/uber/puppet/
-{ cat fabric_settings.example.ini; echo -en "\ngit_regular_nodes_repo = 'https://github.com/magfest/production-config'"; } > fabric_settings.ini
+cat fabric_settings.example.ini > fabric_settings.ini
 ./setup_vagrant_control_server.sh $EVENT_NAME


### PR DESCRIPTION
make a non-magfest specific version of the super-simple deploy.

with one-click now anyone can deploy the RAMS demo/generic event named CoolCon 9000
