### PR TITLE
fix magstock 6 initial deploy

### DIFF
--- a/installfiles/run-simple-deploy.sh
+++ b/installfiles/run-simple-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-EVENT_NAME=prime
+EVENT_NAME=magstock
 
 set -e
 


### PR DESCRIPTION
Switches this to deploy magstock instead of prime.  merge after https://github.com/magfest/production-config/pull/1

Future things we can do to make this more flexible:
1) pass this as an env var from the host OS so it's not hardcoded and people can deploy multiple events in different dirs without editing the file
2) maintain separate branches for different event deploys in this repo.  branch names: magstock, classic, prime, etc.  any common changes go into master and get merged.  we don't expect this repo to really change that much so it's probably not a bad idea.
