### PR TITLE
add command line multi-event support

### DIFF
--- a/CLICK ME TO DEPLOY MAGLABS.bat
+++ b/CLICK ME TO DEPLOY MAGLABS.bat
@@ -1,0 +1,1 @@
+install-windows.bat labs

--- a/CLICK ME TO DEPLOY MAGPRIME.bat
+++ b/CLICK ME TO DEPLOY MAGPRIME.bat
@@ -1,0 +1,1 @@
+install-windows.bat prime

--- a/CLICK ME TO DEPLOY MAGSTOCK.bat
+++ b/CLICK ME TO DEPLOY MAGSTOCK.bat
@@ -1,0 +1,1 @@
+install-windows.bat magstock

--- a/README.md
+++ b/README.md
@@ -1,27 +1,35 @@
-# Magfest Prime deploy
+# Magfest ubersystem simple deploy
 
-This is the officially supported method of setting up a development environment for Magfest's ubersystem.  It will get you a deployment config that is using the same plugins, and nearly the same configuration, as our production servers.
+This is the officially supported method of setting up a development environment for Magfest's ubersystem.  It will get you a deployment config that is using the same plugins, and nearly identical configuration, as our production servers.  Once deployed,
+you can run a command to update all repositories to the latest changes from github.
 
-## Prerequisites
-Install all this stuff:
+## Getting started
+
+First, install all this stuff:
 * [Git](http://git-scm.com/) to check out this repo and to provide SSH.
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads) for running your development VM.
 * [Vagrant](http://www.vagrantup.com/downloads.html) itself.
 
 It's recommended that you have a fast internet connection, at least 4gb of RAM, and a fast PC for this.
 
+## Choose an event
+
+This deploy supports multiple events with different configuration.  Pick an event from [the list of valid events](https://github.com/magfest/simple-rams-deploy/blob/master/valid_eventnames.txt) (examples: 'magstock', 'labs', 'prime')
+
 ## Install instructions (Windows)
 
-1. clone this repo.
-2. run install-windows.bat by double clicking it, or from the command prompt
-3. after the deploy is finished, it will open a web browser, login with username 'magfest@example.com' and password 'magfest'
+1. clone this repository somewhere [Instructions](https://help.github.com/articles/cloning-a-repository/)
+2. open a command prompt and change directories to the location of the repository
+3. type ```install-windows.bat insert-your-event-name-here``` from the terminal.  For example, to install magstock, you would type: ```install-windows.bat magstock```
+4. after the deploy is finished, it will open a web browser, login with username 'magfest@example.com' and password 'magfest'.  If that doesn't work for any reason, just browse to http://localhost:8000/uber/accounts/insert_test_admin
 
 ## Install instructions (Linux/Mac/Cygwin/MingW)
 
-1. clone this repo.
-2. run ```./install-unix.sh``` from the terminal
-3. after the deploy is finished, open a web browser to http://localhost:8000/uber/accounts/insert_test_admin
-4. login with username 'magfest@example.com' and password 'magfest'
+1. clone this repository somewhere [Instructions](https://help.github.com/articles/cloning-a-repository/)
+2. type ```./install-unix.sh insert-your-event-name-here``` from the terminal.  
+   For example, to install magstock, you would type: ```./install-unix.sh magstock```
+3. after the deploy is finished, go open a web browser to http://localhost:8000/uber/accounts/insert_test_admin
+4. now you can login with username 'magfest@example.com' and password 'magfest'
 
 ## To SSH into the machine
 
@@ -33,8 +41,6 @@ https://github.com/magfest/ubersystem-deploy/blob/master/DEVELOPING.md
   
 ## Troubleshooting
 
-If you have previous deployments, you must ensure those VMs are stopped.  Either type 'vagrant halt', or open the 
-Virtualbox program from the start menu and power off any running VMs
+* If you have previous deployments, you must ensure those VMs are stopped.  Either type 'vagrant halt' from their ubersystem-deploy directories, or open the  Virtualbox program from the start menu and power off any running VMs
 
-If you see any Virtualbox errors when starting the process about 'VMX' or 'hardware acceleration', you need to make sure 
-that hardware virtualization acceleration / extensions is enabled in your computer's BIOS.
+* If you see any Virtualbox errors like 'unable to start virtual machine' when starting the process, or anything about 'VMX' or 'hardware acceleration', you may need to make sure that [hardware virtualization acceleration / extensions is enabled](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=virtualbox%20vtx%20disabled%20in%20bios) in your computer's BIOS.

--- a/install-unix.sh
+++ b/install-unix.sh
@@ -1,13 +1,46 @@
 #!/bin/bash
 
+valid_eventnames=("labs" "prime" "magstock")
+
 # fail on any errors
 set -e
 
+function usage() {
+  echo ubersystem deployment setup. ERROR: you must specify which event you want to deploy:
+  echo event_name can be one of the following: ${valid_eventnames[*]}
+  echo usage: $0 [event_name]
+}
+
+array_contains () { 
+    local array="$1[@]"
+    local seeking=$2
+    local in=1
+    for element in "${!array}"; do
+        if [[ $element == $seeking ]]; then
+            in=0
+            break
+        fi
+    done
+    return $in
+}
+
+if [ -z "$1" ]; then
+  usage
+  exit -1
+fi
+
+array_contains valid_eventnames $1 && valid_event=1 || valid_event=0
+if [ $valid_event -eq 0 ]; then 
+  usage
+  exit -1
+fi
+
+vm_cmd="cd ~/uber/ && ./run-simple-deploy.sh $1 && rm -f ./run-simple-deploy.sh"
 git clone https://github.com/magfest/ubersystem-deploy
 cd ubersystem-deploy
 vagrant up
 cp ../installfiles/run-simple-deploy.sh .
-vagrant ssh -c 'cd ~/uber/ && ./run-simple-deploy.sh && rm -f ./run-simple-deploy.sh'
+vagrant ssh -c \'$vm_cmd\'
 
 # not sure how / if we should do this on *nix
 # start http://localhost:8000/uber/accounts/insert_test_admin

--- a/install-unix.sh
+++ b/install-unix.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-valid_eventnames=("labs" "prime" "magstock")
-
 # fail on any errors
 set -e
+
+# read list of valid event names from external file
+IFS=$'\r\n' GLOBIGNORE='*' command eval  'valid_eventnames=($(cat valid_eventnames.txt))'
 
 function usage() {
   echo ubersystem deployment setup. ERROR: you must specify which event you want to deploy:
@@ -34,6 +35,11 @@ if [ $valid_event -eq 0 ]; then
   usage
   exit -1
 fi
+
+# ----------------------------------------
+# meat starts here
+# ----------------------------------------
+echo installling event_nane=$1
 
 vm_cmd="cd ~/uber/ && ./run-simple-deploy.sh $1 && rm -f ./run-simple-deploy.sh"
 git clone https://github.com/magfest/ubersystem-deploy

--- a/install-unix.sh
+++ b/install-unix.sh
@@ -39,7 +39,7 @@ fi
 # ----------------------------------------
 # meat starts here
 # ----------------------------------------
-echo installling event_nane=$1
+echo installling event_name=$1
 
 vm_cmd="cd ~/uber/ && ./run-simple-deploy.sh $1 && rm -f ./run-simple-deploy.sh"
 git clone https://github.com/magfest/ubersystem-deploy

--- a/install-windows.bat
+++ b/install-windows.bat
@@ -26,7 +26,7 @@ echo usage: "%0 EVENT_NAME"
 goto :end
 
 :valid_eventname
-echo installling event_nane=%1%
+echo installling event_name=%1%
 REM ------------------------------------ real stuff starts below --------------------
 
 git clone https://github.com/magfest/ubersystem-deploy || goto :error
@@ -37,7 +37,8 @@ vagrant up || goto :error
 
 copy ..\installfiles\run-simple-deploy.sh . || goto :error
 
-vagrant ssh -c 'cd ~/uber/ ^&^& ./run-simple-deploy.sh %1% ^&^& rm -f ./run-simple-deploy.sh' || goto :error
+set "vm_cmd=cd ~/uber/ ^&^& ./run-simple-deploy.sh %1% ^&^& rm -f ./run-simple-deploy.sh"
+vagrant ssh -c '%vm_cmd%' || goto :error
 
 start http://localhost:8000/uber/accounts/insert_test_admin || goto :error
 

--- a/install-windows.bat
+++ b/install-windows.bat
@@ -2,16 +2,14 @@
 setlocal enableDelayedExpansion
 PATH=%PATH%;C:\Program Files (x86)\Git\bin\;C:\Program Files\Git\bin\;C:\Program Files (x86)\Git\usr\bin\;C:\Program Files\Git\usr\bin\
 
-REM ---- modify this list to include all valid event names
-REM ---- this is Magfest-specific
-set "valid_eventnames=;labs;magstock;prime;"
-REM ------------------------
-REM ------------------------
+for /F "tokens=*" %%A in (valid_eventnames.txt) do (
+	set valid_eventnames=%%A;!valid_eventnames!
+)
 
-IF "%1"=="" goto no_argument
+IF "%1"=="" goto :no_argument
 
 call set "test=%%valid_eventnames:;%~1;=%%"
-if "%test%" neq "%valid_eventnames%" goto valid_eventname
+if "%test%" neq "%valid_eventnames%" goto :valid_eventname
 
 goto :invalid_argument
 
@@ -20,13 +18,14 @@ echo You need to specify an event name when running this command
 
 :invalid_argument
 echo you need to specify an eventname of one of the following: %valid_eventnames%
-goto usage
+goto :usage
 
 :usage
 echo usage: "%0 EVENT_NAME"
 goto :end
 
 :valid_eventname
+echo installling event_nane=%1%
 REM ------------------------------------ real stuff starts below --------------------
 
 git clone https://github.com/magfest/ubersystem-deploy || goto :error
@@ -42,7 +41,7 @@ vagrant ssh -c 'cd ~/uber/ ^&^& ./run-simple-deploy.sh %1% ^&^& rm -f ./run-simp
 start http://localhost:8000/uber/accounts/insert_test_admin || goto :error
 
 echo "deploy should be finished"
-goto end
+goto :end
 
 :error
 echo deploy FAILED with error #%errorlevel%.

--- a/install-windows.bat
+++ b/install-windows.bat
@@ -1,4 +1,33 @@
+@echo off
+setlocal enableDelayedExpansion
 PATH=%PATH%;C:\Program Files (x86)\Git\bin\;C:\Program Files\Git\bin\;C:\Program Files (x86)\Git\usr\bin\;C:\Program Files\Git\usr\bin\
+
+REM ---- modify this list to include all valid event names
+REM ---- this is Magfest-specific
+set "valid_eventnames=;labs;magstock;prime;"
+REM ------------------------
+REM ------------------------
+
+IF "%1"=="" goto no_argument
+
+call set "test=%%valid_eventnames:;%~1;=%%"
+if "%test%" neq "%valid_eventnames%" goto valid_eventname
+
+goto :invalid_argument
+
+:no_argument
+echo You need to specify an event name when running this command
+
+:invalid_argument
+echo you need to specify an eventname of one of the following: %valid_eventnames%
+goto usage
+
+:usage
+echo usage: "%0 EVENT_NAME"
+goto :end
+
+:valid_eventname
+REM ------------------------------------ real stuff starts below --------------------
 
 git clone https://github.com/magfest/ubersystem-deploy || goto :error
 
@@ -8,16 +37,16 @@ vagrant up || goto :error
 
 copy ..\installfiles\run-simple-deploy.sh . || goto :error
 
-vagrant ssh -c 'cd ~/uber/ ^&^& ./run-simple-deploy.sh ^&^& rm -f ./run-simple-deploy.sh' || goto :error
+vagrant ssh -c 'cd ~/uber/ ^&^& ./run-simple-deploy.sh %1% ^&^& rm -f ./run-simple-deploy.sh' || goto :error
 
 start http://localhost:8000/uber/accounts/insert_test_admin || goto :error
 
 echo "deploy should be finished"
-pause
-exit
-
+goto end
 
 :error
-echo Failed with error #%errorlevel%.
+echo deploy FAILED with error #%errorlevel%.
+
+:end
 pause
 exit /b %errorlevel%

--- a/install-windows.bat
+++ b/install-windows.bat
@@ -5,6 +5,7 @@ PATH=%PATH%;C:\Program Files (x86)\Git\bin\;C:\Program Files\Git\bin\;C:\Program
 for /F "tokens=*" %%A in (valid_eventnames.txt) do (
 	set valid_eventnames=%%A;!valid_eventnames!
 )
+set valid_eventnames=;%valid_eventnames%
 
 IF "%1"=="" goto :no_argument
 

--- a/installfiles/run-simple-deploy.sh
+++ b/installfiles/run-simple-deploy.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-
-EVENT_NAME=magstock
-
 set -e
+
+if [[ $# -eq 0 ]] ; then
+  echo "usage: $0 [event_name]"
+  exit -1
+fi
+
+EVENT_NAME=$1
 
 cd ~/uber/puppet/
 { cat fabric_settings.example.ini; echo -en "\ngit_regular_nodes_repo = 'https://github.com/magfest/production-config'"; } > fabric_settings.ini

--- a/valid_eventnames.txt
+++ b/valid_eventnames.txt
@@ -1,0 +1,3 @@
+labs
+magstock
+prime


### PR DESCRIPTION
Make it so the user has to pass in a required event_name argument when deploying 

Goal: can deploy fully customized local magstock, maglabs, or prime install solely by changing the argument.  

Annoying because we have to make a bat file and a bash file depending on the host OS, but otherwise, pretty well worth the cost.  

(All this potentially gets thrown away someday when we used Docker)
- [x] host os: Dos support
- [x] host os: linux / mac support
- [x] test this all out
- [x] update docs to tell user to use an argument

READY FOR MERGE
