### PR TITLE
Update pycharm unit test configs + VCS settings

### DIFF
--- a/.idea/runConfigurations/all_tests.xml
+++ b/.idea/runConfigurations/all_tests.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="uber only" type="tests" factoryName="py.test" singleton="true">
+  <configuration default="false" name="all tests" type="tests" factoryName="py.test" singleton="true">
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs />
-    <option name="SDK_HOME" value="vagrant://$PROJECT_DIR$/ubersystem-deploy/home/vagrant/uber/sideboard/env/bin/python3" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/ubersystem-deploy" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <module name="prime-deploy" />
@@ -17,14 +17,14 @@
         </list>
       </option>
     </PathMappingSettings>
-    <option name="SCRIPT_NAME" value="" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/uber/uber/tests/models/test_attendee.py" />
     <option name="CLASS_NAME" value="" />
-    <option name="METHOD_NAME" value="" />
+    <option name="METHOD_NAME" value="test_is_transferable" />
     <option name="FOLDER_NAME" value="" />
-    <option name="TEST_TYPE" value="TEST_SCRIPT" />
+    <option name="TEST_TYPE" value="TEST_FUNCTION" />
     <option name="PATTERN" value="" />
     <option name="USE_PATTERN" value="false" />
-    <option name="testToRun" value="C:\projects\rams\prime-deploy\ubersystem-deploy\sideboard\plugins\uber\uber\tests\" />
+    <option name="testToRun" value="sideboard/" />
     <option name="keywords" value="" />
     <option name="params" value="-vv" />
     <option name="USE_PARAM" value="true" />

--- a/.idea/runConfigurations/only_uber_plugin_models_tests.xml
+++ b/.idea/runConfigurations/only_uber_plugin_models_tests.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run uber plugin tests" type="tests" factoryName="py.test" singleton="true">
+  <configuration default="false" name="only uber plugin models tests" type="tests" factoryName="py.test" singleton="true">
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs />
-    <option name="SDK_HOME" value="vagrant://$PROJECT_DIR$/ubersystem-deploy/home/vagrant/uber/sideboard/env/bin/python3" />
+    <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/ubersystem-deploy" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <module name="prime-deploy" />
@@ -24,7 +24,7 @@
     <option name="TEST_TYPE" value="TEST_SCRIPT" />
     <option name="PATTERN" value="" />
     <option name="USE_PATTERN" value="false" />
-    <option name="testToRun" value="C:\projects\rams\prime-deploy\ubersystem-deploy\sideboard\plugins\uber\uber\tests\models\test_attendee.py" />
+    <option name="testToRun" value="sideboard/plugins/uber/uber/tests/models/" />
     <option name="keywords" value="" />
     <option name="params" value="-vv" />
     <option name="USE_PARAM" value="true" />

--- a/.idea/runConfigurations/only_uber_plugin_tests_only.xml
+++ b/.idea/runConfigurations/only_uber_plugin_tests_only.xml
@@ -1,13 +1,13 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="all sideboard plugins" type="tests" factoryName="py.test">
+  <configuration default="false" name="only uber plugin tests only" type="tests" factoryName="py.test" singleton="true">
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs />
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/ubersystem-deploy" />
     <option name="IS_MODULE_SDK" value="true" />
-    <option name="ADD_CONTENT_ROOTS" value="false" />
-    <option name="ADD_SOURCE_ROOTS" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
     <module name="prime-deploy" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
     <PathMappingSettings>
@@ -17,14 +17,14 @@
         </list>
       </option>
     </PathMappingSettings>
-    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/uber/uber/tests/models/test_attendee.py" />
+    <option name="SCRIPT_NAME" value="" />
     <option name="CLASS_NAME" value="" />
-    <option name="METHOD_NAME" value="test_is_transferable" />
+    <option name="METHOD_NAME" value="" />
     <option name="FOLDER_NAME" value="" />
-    <option name="TEST_TYPE" value="TEST_FUNCTION" />
+    <option name="TEST_TYPE" value="TEST_SCRIPT" />
     <option name="PATTERN" value="" />
     <option name="USE_PATTERN" value="false" />
-    <option name="testToRun" value="C:\projects\rams\prime-deploy\ubersystem-deploy\sideboard\plugins\" />
+    <option name="testToRun" value="sideboard/plugins/uber/uber/tests/" />
     <option name="keywords" value="" />
     <option name="params" value="-vv" />
     <option name="USE_PARAM" value="true" />

--- a/.idea/runConfigurations/only_unit_tests_in_plugins.xml
+++ b/.idea/runConfigurations/only_unit_tests_in_plugins.xml
@@ -1,13 +1,13 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="plugin unit tests" type="tests" factoryName="py.test">
+  <configuration default="false" name="only unit tests in plugins" type="tests" factoryName="py.test" singleton="true">
     <option name="INTERPRETER_OPTIONS" value="" />
     <option name="PARENT_ENVS" value="true" />
     <envs />
     <option name="SDK_HOME" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/ubersystem-deploy" />
     <option name="IS_MODULE_SDK" value="true" />
-    <option name="ADD_CONTENT_ROOTS" value="false" />
-    <option name="ADD_SOURCE_ROOTS" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
     <module name="prime-deploy" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" enabled="false" sample_coverage="true" runner="coverage.py" />
     <PathMappingSettings>
@@ -24,10 +24,10 @@
     <option name="TEST_TYPE" value="TEST_FUNCTION" />
     <option name="PATTERN" value="" />
     <option name="USE_PATTERN" value="false" />
-    <option name="testToRun" value="C:\projects\rams\prime-deploy\ubersystem-deploy\sideboard\plugins\" />
+    <option name="testToRun" value="sideboard/plugins/" />
     <option name="keywords" value="" />
-    <option name="params" value="" />
-    <option name="USE_PARAM" value="false" />
+    <option name="params" value="-vv" />
+    <option name="USE_PARAM" value="true" />
     <option name="USE_KEYWORD" value="false" />
     <method />
   </configuration>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -10,7 +10,9 @@
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/bands" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/barcode" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/hotel" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/magclassic" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/magprime" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/magstock" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/mivs" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/panels" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/ubersystem-deploy/sideboard/plugins/uber" vcs="Git" />


### PR DESCRIPTION
2 slightly unrelated changes:

1) add all known uber plugins into the pycharm IDE's source control system.  magstock was missing and that would be confusing for new users.

The upside is that all installed plugins, puppet info, sideboard, etc is ready to be hacked on.

The only downside of this is for pycharm users is there's a warning message about missing plugins (because we include all of magclassic, maglabs, magstock in here).  I figure while this might be confusing the first time a new user sees it, it's a decent tradeoff for making everything else easy.

2) update pycharm unit test configurations
- run sideboard+uber unit tests right inside pycharm!
- added a few default choices on how to run tests: all tests, tests in plugins only, uber only, uber models only 
- use relative paths
- use verbose setting on py.test runs

![image](https://cloud.githubusercontent.com/assets/5413064/15215605/5cc83fb6-1821-11e6-98fc-d9a84c035375.png)
