### PR TITLE
make error message look prettier

### DIFF
--- a/install-windows.bat
+++ b/install-windows.bat
@@ -18,6 +18,7 @@ goto :invalid_argument
 echo You need to specify an event name when running this command
 
 :invalid_argument
+set valid_eventnames=%valid_eventnames:;= %
 echo you need to specify an eventname of one of the following: %valid_eventnames%
 goto :usage
 

--- a/install-windows.bat
+++ b/install-windows.bat
@@ -18,8 +18,8 @@ goto :invalid_argument
 echo You need to specify an event name when running this command
 
 :invalid_argument
-set valid_eventnames=%valid_eventnames:;= %
-echo you need to specify an eventname of one of the following: %valid_eventnames%
+set formatted_valid_eventnames=%valid_eventnames:;= %
+echo you need to specify an eventname of one of the following: %formatted_valid_eventnames%
 goto :usage
 
 :usage


### PR DESCRIPTION
for windows users, make the usage look cleaner.

thanks to @earl7399 for the syntax :)

before:
`you need to specify an eventname of one of the following: ;prime;magstock;labs;`

after:
`you need to specify an eventname of one of the following:  prime magstock labs`
