### PR TITLE
OS detection for instructions / auto-open test admin creation

### DIFF
--- a/install-unix.sh
+++ b/install-unix.sh
@@ -51,4 +51,14 @@ vagrant ssh -c \'$vm_cmd\'
 # not sure how / if we should do this on *nix
 # start http://localhost:8000/uber/accounts/insert_test_admin
 
+testadminString="Create your test user at http://localhost:8000/uber/accounts/insert_test_admin"
+
+case "$OSTYPE" in
+  darwin*)  open "http://localhost:8000/uber/accounts/insert_test_admin"  ;; 
+  solaris*) echo $testadminString ;;
+  linux*)   echo $testadminString ;;
+  bsd*)     echo $testadminString ;;
+  *)        echo $testadminString ;;
+esac
+
 echo "deploy should be finished"


### PR DESCRIPTION
Simple case statement using the global $OSTYPE to auto-open a browser
(in the case of OS X) and provide instructions for all other OSes.
Additional lines for detection provided in case a determination is made
to use them, otherwise, all but the darwin line can be
commented/removed.
