### PR TITLE
Set default documentation strings to Google format

### DIFF
--- a/.idea/prime-deploy.iml
+++ b/.idea/prime-deploy.iml
@@ -20,6 +20,9 @@
     <orderEntry type="jdk" jdkName="Remote Python 3.4.3 Vagrant VM at C:/projects/rams/simple-rams-deploy/ubersystem-deploy (/home/vagrant/uber/sideboard/env/bin/python3)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
+  <component name="PyDocumentationSettings">
+    <option name="myDocStringFormat" value="Google" />
+  </component>
   <component name="TemplatesService">
     <option name="templateFileTypes">
       <list>


### PR DESCRIPTION
As mentioned in https://github.com/magfest/sideboard/issues/37, we want to move towards better-looking docstrings. This helps that by making the 'doc string insertion' feature default to the Google docstring format. That means when someone types `"""` and hits Enter, they'll get a docstring template formatted Google-style.
